### PR TITLE
Bump pandoc-types to 1.16, also bump resolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,32 @@
-language: haskell
+# Run on the container infrastructure
+sudo: false
 
-ghc:
-  - "7.8"
+language: c
+
+matrix:
+  include:
+    - env: CABALVER=1.24 GHCVER=7.10.3
+      addons:
+        apt:
+          packages:
+            - cabal-install-1.24
+            - ghc-7.10.3
+          sources:
+            - hvr-ghc
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      addons:
+        apt:
+          packages:
+            - cabal-install-1.18
+            - ghc-7.8.4
+          sources:
+            - hvr-ghc
+
+before_install:
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+script:
+  - cabal update && cabal install --only-dependencies
+  - cabal configure --enable-tests && cabal build && cabal test
+
+

--- a/R-pandoc.cabal
+++ b/R-pandoc.cabal
@@ -18,7 +18,7 @@ source-repository head
 library
     build-depends:
         base         >=4.6  && <4.9,
-        pandoc-types >=1.12 && <1.13,
+        pandoc-types >=1.16 && <1.17,
         directory    >=1.2  && <1.3,
         filepath     >=1.3  && <1.5,
         process      >=1.2  && <1.3,
@@ -33,7 +33,7 @@ library
 executable R-pandoc
     build-depends:
         base         >=4.6  && <4.9,
-        pandoc-types >=1.12 && <1.13,
+        pandoc-types >=1.16 && <1.17,
         R-pandoc     ==0.2.1
     main-is: src/Main.hs
     buildable: True

--- a/src/Text/Pandoc/R.hs
+++ b/src/Text/Pandoc/R.hs
@@ -54,7 +54,7 @@ readImgFiles attrs = case lookup "files" attrs of
    Nothing -> [defFile]
 
 insertImage :: FilePath -> Inline
-insertImage file = Image [] (file,"")
+insertImage file = Image nullAttr [] (file,"")
 
 --plot the R graph
 --the files created will be the one specified in the R code with commands such as:

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-3.2
+resolver: lts-6.8


### PR DESCRIPTION
The latest diagrams-pandoc uses pandoc-types 1.16 (see [diagrams-pandoc-0.3](https://hackage.haskell.org/package/diagrams-pandoc)) this bumps the pandoc-types dependency to 1.16 so the two are easily used together. 

Also bumps the lts resolver to 6.8, which is the latest lts with pandoc-types 1.16 (see [pandoc-types-1.16 stackage](https://www.stackage.org/lts-6.8/package/pandoc-types-1.16.1)).

Thanks for the great tool!
